### PR TITLE
Fix helpers letter case

### DIFF
--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -9,7 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hex/hex.dart';
 import 'package:http/http.dart';
-import 'package:camelus/helpers/Helpers.dart';
+import 'package:camelus/helpers/helpers.dart';
 import 'package:camelus/helpers/bip340.dart';
 import 'package:camelus/models/Tweet.dart';
 import 'package:json_cache/json_cache.dart';


### PR DESCRIPTION
This fixes a build error I got when trying to build on Linux.

```dart
lib/services/nostr/nostr_service.dart:12:8: Error: Error when reading 'lib/helpers/Helpers.dart': No such file or directory
import 'package:camelus/helpers/Helpers.dart';
       ^
lib/services/nostr/nostr_service.dart:27:43: Error: Method not found: 'Helpers'.
  String ownPubkeySubscriptionId = "own-${Helpers().getRandomString(20)}";
                                          ^^^^^^^
lib/services/nostr/nostr_service.dart:270:29: Error: The method 'Helpers' isn't defined for the class 'NostrService'.
 - 'NostrService' is from 'package:camelus/services/nostr/nostr_service.dart' ('lib/services/nostr/nostr_service.dart').
Try correcting the name to the name of an existing method, or defining a method named 'Helpers'.
        var id = "relay-r-${Helpers().getRandomString(5)}";
                            ^^^^^^^
lib/services/nostr/nostr_service.dart:303:29: Error: The method 'Helpers' isn't defined for the class 'NostrService'.
 - 'NostrService' is from 'package:camelus/services/nostr/nostr_service.dart' ('lib/services/nostr/nostr_service.dart').
Try correcting the name to the name of an existing method, or defining a method named 'Helpers'.
        var id = "relay-w-${Helpers().getRandomString(5)}";
                            ^^^^^^^
lib/services/nostr/nostr_service.dart:1331:33: Error: The method 'Helpers' isn't defined for the class 'NostrService'.
 - 'NostrService' is from 'package:camelus/services/nostr/nostr_service.dart' ('lib/services/nostr/nostr_service.dart').
Try correcting the name to the name of an existing method, or defining a method named 'Helpers'.
    var requestId = "metadata-${Helpers().getRandomString(4)}";
                                ^^^^^^^
lib/services/nostr/nostr_service.dart:1414:33: Error: The method 'Helpers' isn't defined for the class 'NostrService'.
 - 'NostrService' is from 'package:camelus/services/nostr/nostr_service.dart' ('lib/services/nostr/nostr_service.dart').
Try correcting the name to the name of an existing method, or defining a method named 'Helpers'.
    var requestId = "contacts-${Helpers().getRandomString(4)}";
                                ^^^^^^^
FAILURE: Build failed with an exception.
```