### PR TITLE
quickfix: resolve conflicted packages

### DIFF
--- a/lib/routes/nostr/nostr_page.dart
+++ b/lib/routes/nostr/nostr_page.dart
@@ -15,7 +15,7 @@ import 'package:camelus/components/tweet_card.dart';
 import 'package:camelus/models/tweet.dart';
 import 'package:camelus/services/nostr/nostr_injector.dart';
 import 'package:camelus/services/nostr/nostr_service.dart';
-import 'package:badges/badges.dart';
+import 'package:badges/badges.dart' as badges;
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../config/palette.dart';
@@ -535,8 +535,8 @@ class _NostrPageState extends State<NostrPage> with TickerProviderStateMixin {
                 centerTitle: true,
                 title: GestureDetector(
                   onTap: () => _syncWithGlobalFeed(),
-                  child: Badge(
-                      animationType: BadgeAnimationType.fade,
+                  child: badges.Badge(
+                      animationType: badges.BadgeAnimationType.fade,
                       toAnimate: false,
                       showBadge: _newTweetsGlobal.isNotEmpty,
                       badgeColor: Palette.primary,


### PR DESCRIPTION
This fixes the following error on Flutter 3.7 and above:

```bash
Launching lib/main.dart on Web Server in debug mode...
lib/routes/nostr/nostr_page.dart:538:26: Error: 'Badge' is imported from both 'package:badges/src/badge.dart' and 'package:flutter/src/material/badge.dart'.
                  child: Badge(
                         ^^^^^
Waiting for connection from debug service on Web Server...         14.3s
Failed to compile application.
```

