### PR TITLE
fix: reply marker position

### DIFF
--- a/lib/data_layer/models/nostr_tag_model.dart
+++ b/lib/data_layer/models/nostr_tag_model.dart
@@ -32,11 +32,12 @@ class NostrTagModel extends NostrTag {
 
     if (value.isNotEmpty) {
       json.add(value);
-      if (recommendedRelay != null) {
+
+      if (marker != null) {
+        json.add(recommendedRelay ?? '');
+        json.add(marker);
+      } else if (recommendedRelay != null) {
         json.add(recommendedRelay);
-        if (marker != null) {
-          json.add(marker);
-        }
       }
     }
 

--- a/lib/domain_layer/entities/nostr_tag.dart
+++ b/lib/domain_layer/entities/nostr_tag.dart
@@ -19,11 +19,11 @@ class NostrTag {
   List<String> toList() {
     List<String> raw = [type, value];
 
-    if (recommendedRelay != null && recommendedRelay!.isNotEmpty) {
-      raw.add(recommendedRelay!);
-    }
     if (marker != null && marker!.isNotEmpty) {
+      raw.add(recommendedRelay ?? '');
       raw.add(marker!);
+    } else if (recommendedRelay != null && recommendedRelay!.isNotEmpty) {
+      raw.add(recommendedRelay!);
     }
 
     return raw;


### PR DESCRIPTION
fixing the position of reply tags:

Before:
```
        [
            "e",
            "bfe0eb84765b06d438edcaa991c4a69749b7de87f7d5ff49fbed5772c5f5d09d",
            "root"
        ],
 ```
 
 
 After:
 ```
        [
            "e",
            "bfe0eb84765b06d438edcaa991c4a69749b7de87f7d5ff49fbed5772c5f5d09d",
             "",
            "root"
        ],
 ```
 