### PR TITLE
fix(login): dismiss keyboard on tap outside, add, and done

### DIFF
--- a/lib/presentation_layer/routes/nostr/onboarding/onboarding_login.dart
+++ b/lib/presentation_layer/routes/nostr/onboarding/onboarding_login.dart
@@ -242,7 +242,11 @@ class _OnboardingLoginPageState extends ConsumerState<OnboardingLoginPage> {
           maxWidth: 700,
           child: LayoutBuilder(
             builder: (context, constraints) {
-              return SingleChildScrollView(
+              return GestureDetector(
+                onTap: () {
+                  FocusManager.instance.primaryFocus?.unfocus();
+                },
+                child: SingleChildScrollView(
                 child: ConstrainedBox(
                   constraints: BoxConstraints(minHeight: constraints.maxHeight),
                   child: IntrinsicHeight(
@@ -388,7 +392,6 @@ class _OnboardingLoginPageState extends ConsumerState<OnboardingLoginPage> {
                             child: TextField(
                               onSubmitted: (value) {
                                 _addWords(value);
-                                _inputFocusNode.requestFocus();
                               },
                               focusNode: _inputFocusNode,
                               autofillHints: Language.english.list,
@@ -483,6 +486,7 @@ class _OnboardingLoginPageState extends ConsumerState<OnboardingLoginPage> {
                                   height: 31,
                                   child: ElevatedButton(
                                     onPressed: () {
+                                      _inputFocusNode.unfocus();
                                       _addWords(_inputController.text);
                                     },
                                     style: ElevatedButton.styleFrom(
@@ -611,6 +615,7 @@ class _OnboardingLoginPageState extends ConsumerState<OnboardingLoginPage> {
                     ),
                   ),
                 ),
+              ),
               );
             },
           ),


### PR DESCRIPTION
- Wrap login page with GestureDetector to unfocus on tap outside
- Hide keyboard when pressing the Add button
- Hide keyboard on TextField submit (Done) instead of refocusing